### PR TITLE
group_incremental_search_add

### DIFF
--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -1,0 +1,69 @@
+$(document).on('turbolinks:load', function(){
+  $(function() {
+
+    var search_list = $("#user-search-result");
+    var member_list = $("#chat-group-users");
+
+    function appendUsers(user) {
+      var html =`<div class="chat-group-user clearfix">
+                  <p class="chat-group-user__name">${ user.name }</p>
+                  <a class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${ user.id }" data-user-name=${ user.name }>追加</a>
+                </div>`
+
+      search_list.append(html);
+    }
+
+    function appendMembers(name, user_id) {
+      var html =`<div class='chat-group-user clearfix js-chat-member' id='chat-group-user'>
+                  <input name='group[user_ids][]' type='hidden' value=${ user_id }>
+                  <p class='chat-group-user__name'>${ name }</p>
+                  <a class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn'>削除</a>
+                </div>`
+
+      member_list.append(html);
+    }
+
+    function appendNoUser(user){
+      var html = `<div class='chat-group-user clearfix'>${ user }</div>`
+      search_list.append(html);
+    }
+
+    
+    $("#user-search-field").on("keyup", function() {
+      var input = $("#user-search-field").val();
+
+      $.ajax({
+        type: 'GET',
+        url: '/users',
+        data: { keyword: input },
+        dataType: 'json'
+      })
+
+      .done(function(users) {
+        $("#user-search-result").empty();
+          if (users.length !== 0) {
+            users.forEach(function(user){
+            appendUsers(user);
+            });
+          }
+          else {
+            appendNoUsers("一致するユーザーはいません");
+          }
+        })
+      .fail(function() {
+        alert('ユーザー検索に失敗しました');
+      })
+    });
+
+    $(document).on('click', '.user-search-add', function() {
+      var name = $(this).data("user-name");
+      var user_id = $(this).data("user-id");
+      $(this).parent().remove();
+      appendMembers(name, user_id);
+    });
+
+    $(document).on("click", '.user-search-remove', function() {
+      $(this).parent().remove();
+    });
+  });
+});

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,14 @@
 class UsersController < ApplicationController
 
+  def index
+    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%")
+    respond_to do |format|
+      format.html
+      format.json
+    end
+  end
+
+
   def edit
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
 
   def index
-    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%")
+    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%").where( "id not in (#{current_user.id})" )
     respond_to do |format|
       format.html
       format.json

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -5,20 +5,36 @@
       %ul
         - group.errors.full_messages.each do |message|
           %li= message
+
   .chat-group-form__field
     .chat-group-form__field--left
       = f.label :name, class: 'chat-group-form__label'
     .chat-group-form__field--right
       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
-  .chat-group-form__field.clearfix
-    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
-      %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
+      = f.label :users, "チャットメンバーを追加", class: 'chat-group-form__label', for:'user-search-field'
     .chat-group-form__field--right
-      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      = f.collection_check_boxes :user_ids, User.all, :id, :name
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+      .chat-group-form__search.clearfix
+        = f.text_field :users, id: 'user-search-field', class: 'chat-group-form__input', value: '', placeholder: '追加したいユーザー名を入力してください'
+      #user-search-result
+
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+      = f.label :user_ids, "チャットメンバー", class: 'chat-group-form__label'
+
+    .chat-group-form__field--right
+      #chat-group-users
+        - @group.users.each do |user|
+          .chat-group-user.clearfix.js-chat-member{id: "#{user.id}"}
+            = hidden_field_tag 'group[user_ids][]', user.id
+            %p.chat-group-user__name #{user.name}
+            - if current_user.id == user.id
+              %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn
+            - else
+              %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn 削除
+       
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id   user.id
+  json.name user.name
+end


### PR DESCRIPTION
#what
インクリメンタルサーチにてグループメンバーの検索機能と非同期通信にてメンバーの追加・削除機能の実装を行った

#why
ページのリダイレクトせずにメンバー検索できることで、スムーズな処理ができるため。