### PR TITLE
image_size_edit

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -2,7 +2,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
   include CarrierWave::MiniMagick
-  process resize_to_fit: [800, 800]
+  process resize_to_fit: [400, 400]
   # Choose what kind of storage to use for this uploader:
   storage :file
   # storage :fog


### PR DESCRIPTION
#what
イメージサイズの変更を行った。

#why
イメージが大きすぎて、サービス上見にくい設定となっていたため。